### PR TITLE
Add component-id annotation and clean catalog-info.yaml for regex-text-transformer

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,14 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: regex-text-transformer
-  description: Transforma conteúdos de texto utilizando regex para fazer alterações em lote em tempo real
-  tags:
-    - text
-    - tools
-    - web
   annotations:
+    custom.backstage.io/component-id: "833a666ce1b8641a450aee1becc870f2be19f1573836f937520c756ca3c48c80"
     github.com/project-slug: rtsarakaki/regex-text-transformer
 spec:
-  type: website
-  lifecycle: experimental
-  owner: group:default/unknown


### PR DESCRIPTION
This PR:

1. Adds the `custom.backstage.io/component-id: "833a666ce1b8641a450aee1becc870f2be19f1573836f937520c756ca3c48c80"` annotation to link this component with the database record
2. Removes fields from catalog-info.yaml that are now stored in the database:
   - metadata.description
   - spec.type
   - spec.lifecycle
   - spec.owner
   - metadata.tags

This was automatically generated when the component was edited via the Components Management interface. The component data is now managed in the database, allowing for easier updates without modifying the repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Backstage catalog metadata to rely on DB-managed fields.
> 
> - Adds `custom.backstage.io/component-id` annotation to `catalog-info.yaml`
> - Removes `metadata.description`, `metadata.tags`, and `spec.type`, `spec.lifecycle`, `spec.owner` (now stored in DB)
> - Retains `github.com/project-slug`; leaves minimal `spec`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fe59be66816b3b1bf9e78432d5b77cc45dc6769. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->