### PR TITLE
Add component-id annotation and clean catalog-info.yaml for regex-text-transformer

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
     custom.backstage.io/component-id: "833a666ce1b8641a450aee1becc870f2be19f1573836f937520c756ca3c48c80"
     github.com/project-slug: rtsarakaki/regex-text-transformer
 spec:
-  system: text-tools
+  system: games
   type: website
   lifecycle: experimental
-  owner: group:default/developers
+  owner: developers


### PR DESCRIPTION
This PR:

1. Adds the `custom.backstage.io/component-id: "833a666ce1b8641a450aee1becc870f2be19f1573836f937520c756ca3c48c80"` annotation to link this component with the database record
2. Synchronizes catalog-info.yaml with the database:
   - Removes metadata.description (now in database)
   - Removes metadata.tags (now in database)
   - Updates spec.type to match database
   - Updates spec.lifecycle to match database
   - Updates spec.owner to match database
   - Updates spec.system to match database

This ensures the catalog-info.yaml stays synchronized with the database. The database is the source of truth, and this PR updates the file to match.

This was automatically generated when the component was edited via the Components Management interface.